### PR TITLE
Publish native library separately with source

### DIFF
--- a/n-api/package.json
+++ b/n-api/package.json
@@ -1,18 +1,48 @@
 {
-  "name": "n-api",
-  "private": true,
-  "version": "1.2.3",
-  "description": "",
+  "name": "win-ca-lib",
+  "version": "2.4.1",
+  "description": "Get Windows System Root certificates",
   "os": [
     "win32"
   ],
   "gypfile": true,
-  "main": "index.js",
+  "main": "build/Release/crypt32",
+  "files": [
+    "binding.gyp",
+    "crypt32.cc",
+    "roots.c"
+  ],
   "scripts": {
     "test": "node test",
     "deploy": "node deploy"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+  "repository": {
+    "type": "git",
+    "url": "git+https://ukoloff@github.com/ukoloff/win-ca.git"
+  },
+  "keywords": [
+    "n-api",
+    "ssl",
+    "tls",
+    "ca",
+    "root",
+    "windows",
+    "vscode",
+    "electron"
+  ],
+  "author": {
+    "name": "Stas Ukolov",
+    "email": "ukoloff@gmail.com"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ukoloff/win-ca/issues"
+  },
+  "homepage": "https://github.com/ukoloff/win-ca",
+  "dependencies": {
+    "node-addon-api": "^1.3.0"
+  },
+  "devDependencies": {
+    "bindings": "^1.3.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "split": "^1.0.1"
   },
   "devDependencies": {
-    "bindings": "^1.3.0",
-    "coffee-script": "^1.12.2",
-    "node-addon-api": "^1.3.0"
+    "coffee-script": "^1.12.2"
   }
 }


### PR DESCRIPTION
Hi @ukoloff,

I'm looking into including `win-ca` in VS Code and would like to do that in a way that I can load the list of certificates and then apply them to individual https requests.

The way win-ca updates the global certificate list, writes the certificates to files and sets an environment variable is great when you don't need much control, but just want things to work. For VS Code it would be preferable, if we had a way to only load the certificates and not change any global state or write any files.

Maybe the easiest way to do that would be if the native module in the `n-api` folder was available as a separate npm package. If that package comes with the source code we can even compile it against Electron and that will then work without the need for the `roots.exe` fallback.

This PR updates the two `package.json`, such that you can publish the native module as `win-ca-lib`. The changes shouldn't break your existing setup I believe, but I haven't checked.

Let me know what you think.
