### PR TITLE
Fix win-ca for asar packaged electron apps

### DIFF
--- a/src/fallback.ls
+++ b/src/fallback.ls
@@ -2,7 +2,7 @@
 
 require! <[ path child_process split ]>
 
-bin = path.join __dirname, 'roots'
+bin = path.join __dirname, 'roots.exe'
 
 export !function sync(args)
   return {run, next, done}


### PR DESCRIPTION
This makes win-ca work with electron if app is asar packaged.